### PR TITLE
GHC 8.4 & megaparsec 6.3 compat

### DIFF
--- a/GameEngine/Collision.hs
+++ b/GameEngine/Collision.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, ViewPatterns, BangPatterns #-}
+{-# LANGUAGE CPP, RecordWildCards, ViewPatterns, BangPatterns #-}
 module GameEngine.Collision
   ( TraceHit(..)
   , traceRay
@@ -64,7 +64,12 @@ boolean outputAllSolid;  -- mappend: or
 
 instance Monoid TraceHit where
   mempty = TraceHit 1 True False []
+#if !MIN_VERSION_base(4,11,0)
   (TraceHit a1 b1 c1 d1) `mappend` (TraceHit a2 b2 c2 d2) = TraceHit (min a1 a2) (b1 && b2) (c1 || c2) (d1 `mappend` d2)
+#else
+instance Semigroup TraceHit where
+  (TraceHit a1 b1 c1 d1) <> (TraceHit a2 b2 c2 d2) = TraceHit (min a1 a2) (b1 && b2) (c1 || c2) (d1 <> d2)
+#endif
 
 epsilon = 1/32 :: Float
 

--- a/GameEngine/Content.hs
+++ b/GameEngine/Content.hs
@@ -9,6 +9,7 @@ import System.FilePath
 import Text.Printf
 import Data.Map (Map)
 import qualified Data.Map as Map
+import qualified Data.ByteString.Char8 as BS8
 
 import GameEngine.Data.Material hiding (Vec3)
 import GameEngine.Loader.ShaderParser
@@ -22,7 +23,7 @@ loadPK3 = do
 
 loadShaderMap :: Map String Entry -> IO (Map String CommonAttrs)
 loadShaderMap ar = do
-  l <- sequence <$> forM [(n,e) | (n,e) <- Map.toList ar, ".shader" == takeExtension n, isPrefixOf "scripts" n] (\(n,e) -> parseShaders (eArchiveName e ++ ":" ++ n) <$> readEntry e)
+  l <- sequence <$> forM [(n,e) | (n,e) <- Map.toList ar, ".shader" == takeExtension n, isPrefixOf "scripts" n] (\(n,e) -> parseShaders (eArchiveName e ++ ":" ++ n) . BS8.unpack <$> readEntry e)
   case l of
     Left err -> fail err
     Right (unzip -> (x,w)) -> do

--- a/GameEngine/Graphics/GameCharacter.hs
+++ b/GameEngine/Graphics/GameCharacter.hs
@@ -90,7 +90,7 @@ addCharacterInstance pk3 storage name skin = do
         skin <- readSkin <$> getEntry (skinName part)
         addMD3 storage model skin ["worldMat","entityRGB","entityAlpha"]
 
-  character <- parseCharacter animationName <$> getEntry animationName >>= \case
+  character <- parseCharacter animationName . unpack <$> getEntry animationName >>= \case
     Left message  -> fail message
     Right a -> return a
 

--- a/game/GameMain.hs
+++ b/game/GameMain.hs
@@ -175,7 +175,7 @@ loadMap = do
   SB.writeFile (lc_q3_cache </> bspName ++ ".entities") $ blEntities bsp
 
   -- extract spawn points
-  let ents = case E.parseEntities bspName $ blEntities bsp of
+  let ents = case E.parseEntities bspName $ SB.unpack $ blEntities bsp of
           Left err -> error err
           Right x -> x
   return (pk3Data,loadEntities ents,fullBSPName)

--- a/mapviewer/Content.hs
+++ b/mapviewer/Content.hs
@@ -101,7 +101,7 @@ readCharacters pk3Data p0 = do
           characterModels = [[(characterModelSkin name skin part,printf "models/players/%s/%s.md3" name part) | part <- ["head","upper","lower"]] | (name,skin) <- characterNames]
 
   charactersResult <- sequence <$> sequence
-    [ parseCharacter fname <$> readEntry e
+    [ parseCharacter fname . SB.unpack <$> readEntry e
     | (name,skin) <- characterNames
     , let fname = "models/players/" ++ name ++ "/animation.cfg"
           e = maybe (error $ "missing " ++ fname) id $ Map.lookup fname pk3Data

--- a/mapviewer/Engine.hs
+++ b/mapviewer/Engine.hs
@@ -103,7 +103,7 @@ engineInit pk3Data fullBSPName = do
     SB.writeFile (lc_q3_cache </> bspName ++ ".entities") $ blEntities bsp
 
     -- extract spawn points
-    let ents = case E.parseEntities bspName $ blEntities bsp of
+    let ents = case E.parseEntities bspName $ SB.unpack $ blEntities bsp of
             Left err -> error err
             Right x -> x
         spawnPoint E.EntityData{..}


### PR DESCRIPTION
This builds on GHC 8.4.1-alpha1.

Note that this introduces a regression -- the game character, entity and shader parsers now parse Strings, not ByteStrings.  I couldn't really figure out how the combination of those was supposed to work, in the first place.. : -/